### PR TITLE
Submodule permissions fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib"]
 	path = lib
-	url = git@github.com:CoderDojoChi/FinchPython.git
+	url = https://github.com/CoderDojoChi/FinchPython.git

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Quickstart
 
 ```bash
-git clone git@github.com:CoderDojoChi/FinchPythonDemos.git
+git clone https://github.com/CoderDojoChi/FinchPythonDemos.git
 cd FinchPythonDemos
 git submodule init
 git submodule update


### PR DESCRIPTION
I was getting a permissions error when I tried to run git submodule, so I changed the URL to the https version in .gitmodules as well as the README.md. I'm not too familiar with submodules, so maybe it was my mistake, but I've run into permissions errors with git@github.com URLs so thought it might be helpful