### PR TITLE
Added padding to remote control output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.DS_Store

--- a/RemoteControl.py
+++ b/RemoteControl.py
@@ -9,37 +9,45 @@ myFinch = Finch()
 Control Finch with keys
 """
 
-stdscr = curses.initscr()
+# Initialize the library. Return a WindowObject which represents the whole screen.
+window = curses.initscr()
 curses.cbreak()
-stdscr.keypad(1)
+window.keypad(1)
 
-stdscr.addstr(0, 10, "Hit 'q' to quit")
-stdscr.refresh()
+window.addstr(0, 0, "Hit 'q' to quit")
+window.move(2, 0)
+window.refresh()
 
 key = ''
 while key != ord('q'):
-    key = stdscr.getch()
-    stdscr.addch(20, 25, key)
-    stdscr.clear()
-    stdscr.addstr(0, 10, "Hit 'q' to quit")
+    key = window.getch()
+    window.addch(2, 0, key)
+    window.refresh()
 
     if key == curses.KEY_UP:
-        stdscr.addstr(1, 20, "Finch goes forward!")
+        window.clrtobot()
+        window.addstr(2, 0, "Finch goes forward!")
         myFinch.wheels(1, 1)
         sleep(0.1)
         myFinch.halt()
+
     elif key == curses.KEY_DOWN:
-        stdscr.addstr(1, 20, "Finch goes backwards!")
+        window.clrtobot()
+        window.addstr(2, 0, "Finch goes backwards!")
         myFinch.wheels(-1, -1)
         sleep(0.1)
         myFinch.halt()
+
     elif key == curses.KEY_LEFT:
-    	stdscr.addstr(1, 20, "Finch goes left!")
+        window.clrtobot()
+        window.addstr(2, 0, "Finch goes left!")
         myFinch.wheels(0, 1)
         sleep(0.1)
         myFinch.halt()
+
     elif key == curses.KEY_RIGHT:
-    	stdscr.addstr(1, 20, "Finch goes right!")
+        window.clrtobot()
+        window.addstr(2, 0, "Finch goes right!")
         myFinch.wheels(1, 0)
         sleep(0.1)
         myFinch.halt()

--- a/RemoteControl.py
+++ b/RemoteControl.py
@@ -17,7 +17,7 @@ stdscr.addstr(0, 10, "Hit 'q' to quit")
 stdscr.refresh()
 
 key = ''
-padding = "     "
+padding = " " * 5
 while key != ord('q'):
     key = stdscr.getch()
     stdscr.addch(20, 25, key)

--- a/RemoteControl.py
+++ b/RemoteControl.py
@@ -17,28 +17,29 @@ stdscr.addstr(0, 10, "Hit 'q' to quit")
 stdscr.refresh()
 
 key = ''
+padding = "     "
 while key != ord('q'):
     key = stdscr.getch()
     stdscr.addch(20, 25, key)
     stdscr.refresh()
 
-    if key == curses.KEY_UP: 
-        stdscr.addstr(1, 20, "Finch goes forward!")
+    if key == curses.KEY_UP:
+        stdscr.addstr(1, 20, "Finch goes forward!" + padding)
         myFinch.wheels(1, 1)
         sleep(0.1)
         myFinch.halt()
-    elif key == curses.KEY_DOWN: 
-        stdscr.addstr(1, 20, "Finch goes backwards!")
+    elif key == curses.KEY_DOWN:
+        stdscr.addstr(1, 20, "Finch goes backwards!" + padding)
         myFinch.wheels(-1, -1)
         sleep(0.1)
         myFinch.halt()
     elif key == curses.KEY_LEFT:
-    	stdscr.addstr(1, 20, "Finch goes left!")
+    	stdscr.addstr(1, 20, "Finch goes left!" + padding)
         myFinch.wheels(0, 1)
         sleep(0.1)
         myFinch.halt()
     elif key == curses.KEY_RIGHT:
-    	stdscr.addstr(1, 20, "Finch goes right!")	
+    	stdscr.addstr(1, 20, "Finch goes right!" + padding)
         myFinch.wheels(1, 0)
         sleep(0.1)
         myFinch.halt()

--- a/RemoteControl.py
+++ b/RemoteControl.py
@@ -17,29 +17,29 @@ stdscr.addstr(0, 10, "Hit 'q' to quit")
 stdscr.refresh()
 
 key = ''
-padding = " " * 5
 while key != ord('q'):
     key = stdscr.getch()
     stdscr.addch(20, 25, key)
-    stdscr.refresh()
+    stdscr.clear()
+    stdscr.addstr(0, 10, "Hit 'q' to quit")
 
     if key == curses.KEY_UP:
-        stdscr.addstr(1, 20, "Finch goes forward!" + padding)
+        stdscr.addstr(1, 20, "Finch goes forward!")
         myFinch.wheels(1, 1)
         sleep(0.1)
         myFinch.halt()
     elif key == curses.KEY_DOWN:
-        stdscr.addstr(1, 20, "Finch goes backwards!" + padding)
+        stdscr.addstr(1, 20, "Finch goes backwards!")
         myFinch.wheels(-1, -1)
         sleep(0.1)
         myFinch.halt()
     elif key == curses.KEY_LEFT:
-    	stdscr.addstr(1, 20, "Finch goes left!" + padding)
+    	stdscr.addstr(1, 20, "Finch goes left!")
         myFinch.wheels(0, 1)
         sleep(0.1)
         myFinch.halt()
     elif key == curses.KEY_RIGHT:
-    	stdscr.addstr(1, 20, "Finch goes right!" + padding)
+    	stdscr.addstr(1, 20, "Finch goes right!")
         myFinch.wheels(1, 0)
         sleep(0.1)
         myFinch.halt()


### PR DESCRIPTION
RemoteControl.py outputs direction statements like "Finch goes forward!" through curses, but because the statements were different lengths and curses only replaces the characters you add, things were getting outputted like "Finch goes left!rds!". 

I added some padding spaces to make sure everything gets overwritten. I couldn't find a super clean way, but I didn't do a ton of research so let me know if there is one